### PR TITLE
Update to use Node 20 per GitHub

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -13,10 +13,10 @@ jobs:
   run-build-test:
     strategy:
       matrix:
-        version: [ 16, 18, 20 ]
+        version: [ 20 ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           yarn
           yarn build:once

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ outputs:
   deploymentDetails:
     description: 'Forwarded Vercel API response - See https://vercel.com/docs/api#endpoints/deployments/get-a-single-deployment/response-parameters'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'github-action-runtime/index.js'


### PR DESCRIPTION
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.